### PR TITLE
Adjust to new authentication method for Zabbix 2.4:

### DIFF
--- a/src/com/inovex/zabbixmobile/data/ZabbixRemoteAPI.java
+++ b/src/com/inovex/zabbixmobile/data/ZabbixRemoteAPI.java
@@ -291,7 +291,7 @@ public class ZabbixRemoteAPI {
 
 		String auth = "null";
 		if (mZabbixAuthToken != null
-				&& method != "user.authenticate")
+				&& method != "user.login")
 			auth = "\"" + mZabbixAuthToken + "\"";
 
 		Log.d(TAG, "queryBuffer: " + zabbixUrl);
@@ -542,7 +542,7 @@ public class ZabbixRemoteAPI {
 
 		String token = null;
 		try {
-			JSONObject result = _queryBuffer("user.authenticate",
+			JSONObject result = _queryBuffer("user.login",
 					new JSONObject().put("user", user)
 							.put("password", password));
 			token = result.getString("result");


### PR DESCRIPTION
Line 294 & 545: change user.authenticate to user.login for Zabbix version 2.4
No backward compatibility! ?ideas?

This should deal with "Internal Error" message that comes from Zabbix 2.3.2 (2.4).
But because API version request also requires a login, I did not think of option to detect this and correct login method can be used...
