### PR TITLE
Show template screens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-core:2.4.0'
     compile 'com.pubnub:pubnub:3.5.6'
     compile 'com.jjoe64:graphview:3.1.3'
+    compile 'com.facebook.stetho:stetho:1.1.1'
 }
 
 android {

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -25,8 +25,9 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/icon"
-        android:label="@string/app_name" >
-        <activity
+        android:label="@string/app_name"
+        android:name=".MyApplication">
+    <activity
             android:name=".activities.ProblemsActivity"
             android:label="@string/app_name" >
             <intent-filter>

--- a/src/main/java/com/inovex/zabbixmobile/MyApplication.java
+++ b/src/main/java/com/inovex/zabbixmobile/MyApplication.java
@@ -1,0 +1,36 @@
+/*
+This file is part of ZAX.
+
+	ZAX is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	ZAX is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with ZAX.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.inovex.zabbixmobile;
+
+import android.app.Application;
+
+import com.facebook.stetho.Stetho;
+
+/**
+ * Created by jschamburger on 28.08.15.
+ */
+public class MyApplication extends Application {
+
+    public void onCreate() {
+        super.onCreate();
+        Stetho.initialize(Stetho.newInitializerBuilder(this).enableDumpapp(
+                Stetho.defaultDumperPluginsProvider(this)).enableWebKitInspector(
+                Stetho.defaultInspectorModulesProvider(this)).build());
+    }
+
+}

--- a/src/main/java/com/inovex/zabbixmobile/adapters/ScreensListAdapter.java
+++ b/src/main/java/com/inovex/zabbixmobile/adapters/ScreensListAdapter.java
@@ -39,7 +39,6 @@ public class ScreensListAdapter extends BaseServiceAdapter<Screen> {
 	 * Constructor.
 	 * 
 	 * @param service
-	 * @param textViewResourceId
 	 */
 	public ScreensListAdapter(ZabbixDataService service) {
 		super(service);
@@ -58,7 +57,12 @@ public class ScreensListAdapter extends BaseServiceAdapter<Screen> {
 
 		Screen s = getItem(position);
 
-		title.setText(s.getName());
+		StringBuilder titleBuilder = new StringBuilder();
+		if(s.getHost() != null) {
+			titleBuilder.append(s.getHost().getName() + " - ");
+		}
+		titleBuilder.append(s.getName());
+		title.setText(titleBuilder.toString());
 
 		return row;
 	}
@@ -67,7 +71,7 @@ public class ScreensListAdapter extends BaseServiceAdapter<Screen> {
 	public long getItemId(int position) {
 		Screen item = getItem(position); 
 		if (item != null)
-			return item.getId();
+			return item.getScreenId();
 		return 0;
 	}
 

--- a/src/main/java/com/inovex/zabbixmobile/data/DatabaseHelper.java
+++ b/src/main/java/com/inovex/zabbixmobile/data/DatabaseHelper.java
@@ -76,7 +76,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 	private static final String DATABASE_NAME = "zabbixmobile2.db";
 	// any time you make changes to your database objects, you may have to
 	// increase the database version
-	private static final int DATABASE_VERSION = 10;
+	private static final int DATABASE_VERSION = 11;
 	private static final String TAG = DatabaseHelper.class.getSimpleName();
 	private DatabaseConnection mThreadConnection;
 	private final Context mContext;
@@ -526,7 +526,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 		try {
 			Dao<ScreenItem, Long> screenItemDao = getDao(ScreenItem.class);
 			List<ScreenItem> screenItems = screenItemDao.queryForEq(
-					ScreenItem.COLUMN_SCREENID, screen.getId());
+					ScreenItem.COLUMN_SCREENID, screen.getScreenId());
 
 			HashSet<Long> graphIds = new HashSet<Long>();
 			for (ScreenItem s : screenItems) {
@@ -1437,4 +1437,5 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 			handleException(new FatalException(Type.INTERNAL_ERROR, e));
 		}
 	}
+
 }

--- a/src/main/java/com/inovex/zabbixmobile/data/DatabaseHelper.java
+++ b/src/main/java/com/inovex/zabbixmobile/data/DatabaseHelper.java
@@ -76,7 +76,7 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 	private static final String DATABASE_NAME = "zabbixmobile2.db";
 	// any time you make changes to your database objects, you may have to
 	// increase the database version
-	private static final int DATABASE_VERSION = 11;
+	private static final int DATABASE_VERSION = 13;
 	private static final String TAG = DatabaseHelper.class.getSimpleName();
 	private DatabaseConnection mThreadConnection;
 	private final Context mContext;
@@ -530,7 +530,11 @@ public class DatabaseHelper extends OrmLiteSqliteOpenHelper {
 
 			HashSet<Long> graphIds = new HashSet<Long>();
 			for (ScreenItem s : screenItems) {
-				graphIds.add(s.getResourceId());
+				if(s.getRealResourceId() != null) {
+					graphIds.add(s.getRealResourceId());
+				} else {
+					graphIds.add(s.getResourceId());
+				}
 			}
 			return graphIds;
 		} catch (SQLException e) {

--- a/src/main/java/com/inovex/zabbixmobile/model/Screen.java
+++ b/src/main/java/com/inovex/zabbixmobile/model/Screen.java
@@ -17,22 +17,32 @@ This file is part of ZAX.
 
 package com.inovex.zabbixmobile.model;
 
-import java.util.Collection;
-
 import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.table.DatabaseTable;
+
+import java.util.Collection;
 
 @DatabaseTable(tableName = "screens")
 public class Screen implements Comparable<Screen> {
 
+	private static final String INDEX_SCREENID_HOST = "screen_host_idx";
+	/** row ID */
+	public static final String COLUMN_ID = "id";
+	@DatabaseField(generatedId = true, columnName = COLUMN_ID)
+	long id;
 	/** Screen ID */
 	public static final String COLUMN_SCREENID = "screenid";
-	@DatabaseField(id = true, columnName = COLUMN_SCREENID)
-	long id;
+	@DatabaseField(uniqueIndexName = INDEX_SCREENID_HOST, columnName = COLUMN_SCREENID)
+	long screenId;
 	/** Screen name */
 	public static final String COLUMN_NAME = "name";
 	@DatabaseField(columnName = COLUMN_NAME)
 	String name;
+
+	/** Host (needed for templates */
+	public static final String COLUMN_HOST = "host";
+	@DatabaseField(uniqueIndexName = INDEX_SCREENID_HOST, foreign = true, foreignAutoRefresh = true, columnName = COLUMN_HOST)
+	Host host;
 
 	/** zabbix server */
 	public static final String COLUMN_ZABBIXSERVER_ID = "zabbixserverid";
@@ -48,6 +58,14 @@ public class Screen implements Comparable<Screen> {
 		return id;
 	}
 
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public long getScreenId() {
+		return screenId;
+	}
+
 	public String getName() {
 		return name;
 	}
@@ -60,8 +78,8 @@ public class Screen implements Comparable<Screen> {
 		this.graphs = graphs;
 	}
 
-	public void setId(long screenId) {
-		this.id = screenId;
+	public void setScreenId(long screenId) {
+		this.screenId = screenId;
 	}
 
 	public void setName(String name) {
@@ -70,9 +88,11 @@ public class Screen implements Comparable<Screen> {
 
 	@Override
 	public int compareTo(Screen another) {
-		if (another.getId() < id)
+		if (another.getScreenId() < screenId)
 			return 1;
-		if (another.getId() > id)
+		if (another.getScreenId() > screenId)
+			return -1;
+		if(!another.getHost().equals(host))
 			return -1;
 		return 0;
 	}
@@ -85,4 +105,11 @@ public class Screen implements Comparable<Screen> {
 		this.zabbixServerId = zabbixServerId;
 	}
 
+	public Host getHost() {
+		return host;
+	}
+
+	public void setHost(Host host) {
+		this.host = host;
+	}
 }

--- a/src/main/java/com/inovex/zabbixmobile/model/ScreenItem.java
+++ b/src/main/java/com/inovex/zabbixmobile/model/ScreenItem.java
@@ -23,10 +23,15 @@ import com.j256.ormlite.table.DatabaseTable;
 @DatabaseTable(tableName = "screenitems")
 public class ScreenItem {
 
+	private static final String INDEX_SCREENITEMID_HOST = "screenitem_host_idx";
+	/** row ID */
+	public static final String COLUMN_ID = "id";
+	@DatabaseField(generatedId = true, columnName = COLUMN_ID)
+	long id;
 	/** screen Item ID */
 	public static final String COLUMN_SCREENITEMID = "screenitemid";
-	@DatabaseField(id = true, columnName = COLUMN_SCREENITEMID)
-	long id;
+	@DatabaseField(uniqueIndexName = INDEX_SCREENITEMID_HOST, columnName = COLUMN_SCREENITEMID)
+	long screenItemId;
 	/** screen ID */
 	public static final String COLUMN_SCREENID = "screenid";
 	@DatabaseField(columnName = COLUMN_SCREENID, index = true)
@@ -35,13 +40,21 @@ public class ScreenItem {
 	public static final String COLUMN_RESOURCEID = "resourceid";
 	@DatabaseField(columnName = COLUMN_RESOURCEID)
 	long resourceId;
+	/** host (used for template screens) */
+	public static final String COLUMN_HOST = "host";
+	@DatabaseField(foreign = true, foreignAutoRefresh = true, uniqueIndexName = INDEX_SCREENITEMID_HOST, columnName = COLUMN_HOST)
+	Host host;
+	/** real graph id (used for template screens) */
+	public static final String COLUMN_REAL_RESOURCEID = "real_resourceid";
+	@DatabaseField(columnName = COLUMN_REAL_RESOURCEID)
+	Long realResourceId;
 
 	public ScreenItem() {
 
 	}
 
-	public long getId() {
-		return id;
+	public long getScreenItemId() {
+		return screenItemId;
 	}
 
 	public long getScreenId() {
@@ -52,8 +65,8 @@ public class ScreenItem {
 		return resourceId;
 	}
 
-	public void setId(long id) {
-		this.id = id;
+	public void setScreenItemId(long screenItemId) {
+		this.screenItemId = screenItemId;
 	}
 
 	public void setScreenId(long screenId) {
@@ -64,4 +77,19 @@ public class ScreenItem {
 		this.resourceId = resourceId;
 	}
 
+	public Host getHost() {
+		return host;
+	}
+
+	public void setHost(Host host) {
+		this.host = host;
+	}
+
+	public Long getRealResourceId() {
+		return realResourceId;
+	}
+
+	public void setRealResourceId(Long realResourceId) {
+		this.realResourceId = realResourceId;
+	}
 }

--- a/src/main/res/raw/ormlite_config.txt
+++ b/src/main/res/raw/ormlite_config.txt
@@ -1,23 +1,25 @@
 #
-# generated on 2014/03/31 05:29:59
+# generated on 2015/08/28 03:51:37
 #
 # --table-start--
-dataClass=com.inovex.zabbixmobile.model.ScreenItem
-tableName=screenitems
+dataClass=com.inovex.zabbixmobile.model.Application
+tableName=applications
 # --table-fields-start--
 # --field-start--
 fieldName=id
-columnName=screenitemid
+columnName=applicationid
 id=true
 # --field-end--
 # --field-start--
-fieldName=screenId
-columnName=screenid
-indexName=screenitems_screenid_idx
+fieldName=host
+columnName=hostid
+foreign=true
+indexName=applications_hostid_idx
+foreignAutoRefresh=true
 # --field-end--
 # --field-start--
-fieldName=resourceId
-columnName=resourceid
+fieldName=name
+columnName=name
 # --field-end--
 # --table-fields-end--
 # --table-end--
@@ -52,6 +54,119 @@ foreignAutoRefresh=true
 # --table-end--
 #################################
 # --table-start--
+dataClass=com.inovex.zabbixmobile.model.Cache
+tableName=cache
+# --table-fields-start--
+# --field-start--
+fieldName=id
+generatedId=true
+# --field-end--
+# --field-start--
+fieldName=type
+columnName=type
+uniqueIndexName=cache_idx
+# --field-end--
+# --field-start--
+fieldName=itemId
+columnName=item_id
+uniqueIndexName=cache_idx
+# --field-end--
+# --field-start--
+fieldName=expireTime
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.Event
+tableName=events
+# --table-fields-start--
+# --field-start--
+fieldName=id
+columnName=eventid
+id=true
+# --field-end--
+# --field-start--
+fieldName=objectId
+columnName=objectid
+# --field-end--
+# --field-start--
+fieldName=trigger
+columnName=triggerid
+foreign=true
+foreignAutoRefresh=true
+foreignAutoCreate=true
+# --field-end--
+# --field-start--
+fieldName=clock
+columnName=clock
+# --field-end--
+# --field-start--
+fieldName=value
+columnName=value
+# --field-end--
+# --field-start--
+fieldName=acknowledged
+columnName=acknowledged
+# --field-end--
+# --field-start--
+fieldName=hostNames
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.Graph
+tableName=graphs
+# --table-fields-start--
+# --field-start--
+fieldName=id
+columnName=graphid
+id=true
+# --field-end--
+# --field-start--
+fieldName=name
+columnName=name
+# --field-end--
+# --field-start--
+fieldName=graphItems
+columnName=graphitems
+foreignCollection=true
+foreignCollectionEager=true
+foreignCollectionColumnName=graphitems
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.GraphItem
+tableName=graphitems
+# --table-fields-start--
+# --field-start--
+fieldName=id
+columnName=graphitemid
+id=true
+unique=true
+# --field-end--
+# --field-start--
+fieldName=item
+columnName=itemid
+foreign=true
+foreignAutoRefresh=true
+# --field-end--
+# --field-start--
+fieldName=graph
+columnName=graphid
+foreign=true
+# --field-end--
+# --field-start--
+fieldName=color
+columnName=color
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
 dataClass=com.inovex.zabbixmobile.model.HistoryDetail
 tableName=historydetails
 # --table-fields-start--
@@ -72,6 +187,69 @@ columnName=clock
 # --field-start--
 fieldName=value
 columnName=value
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.Host
+tableName=hosts
+# --table-fields-start--
+# --field-start--
+fieldName=id
+columnName=hostid
+id=true
+# --field-end--
+# --field-start--
+fieldName=name
+columnName=host
+# --field-end--
+# --field-start--
+fieldName=status
+columnName=status
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.HostGroup
+tableName=hostgroups
+# --table-fields-start--
+# --field-start--
+fieldName=groupId
+columnName=groupid
+id=true
+# --field-end--
+# --field-start--
+fieldName=name
+columnName=name
+# --field-end--
+# --field-start--
+fieldName=zabbixServerId
+columnName=zabbixserverid
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.HostHostGroupRelation
+tableName=host_hostgroup_relation
+# --table-fields-start--
+# --field-start--
+fieldName=id
+generatedId=true
+# --field-end--
+# --field-start--
+fieldName=host
+columnName=hostid
+foreign=true
+uniqueIndexName=host_group_idx
+# --field-end--
+# --field-start--
+fieldName=group
+columnName=groupid
+foreign=true
+uniqueIndexName=host_group_idx
 # --field-end--
 # --table-fields-end--
 # --table-end--
@@ -119,216 +297,54 @@ columnName=status
 # --table-end--
 #################################
 # --table-start--
-dataClass=com.inovex.zabbixmobile.model.Graph
-tableName=graphs
-# --table-fields-start--
-# --field-start--
-fieldName=id
-columnName=graphid
-id=true
-# --field-end--
-# --field-start--
-fieldName=name
-columnName=name
-# --field-end--
-# --field-start--
-fieldName=graphItems
-columnName=graphitems
-foreignCollection=true
-foreignCollectionEager=true
-foreignCollectionColumnName=graphitems
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.Application
-tableName=applications
-# --table-fields-start--
-# --field-start--
-fieldName=id
-columnName=applicationid
-id=true
-# --field-end--
-# --field-start--
-fieldName=host
-columnName=hostid
-foreign=true
-indexName=applications_hostid_idx
-foreignAutoRefresh=true
-# --field-end--
-# --field-start--
-fieldName=name
-columnName=name
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.Cache
-tableName=cache
-# --table-fields-start--
-# --field-start--
-fieldName=id
-generatedId=true
-# --field-end--
-# --field-start--
-fieldName=type
-columnName=type
-uniqueIndexName=cache_idx
-# --field-end--
-# --field-start--
-fieldName=itemId
-columnName=item_id
-uniqueIndexName=cache_idx
-# --field-end--
-# --field-start--
-fieldName=expireTime
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.GraphItem
-tableName=graphitems
-# --table-fields-start--
-# --field-start--
-fieldName=id
-columnName=graphitemid
-id=true
-unique=true
-# --field-end--
-# --field-start--
-fieldName=item
-columnName=itemid
-foreign=true
-foreignAutoRefresh=true
-# --field-end--
-# --field-start--
-fieldName=graph
-columnName=graphid
-foreign=true
-# --field-end--
-# --field-start--
-fieldName=color
-columnName=color
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
 dataClass=com.inovex.zabbixmobile.model.Screen
 tableName=screens
 # --table-fields-start--
 # --field-start--
 fieldName=id
+columnName=id
+generatedId=true
+# --field-end--
+# --field-start--
+fieldName=screenId
 columnName=screenid
-id=true
+uniqueIndexName=screen_host_idx
 # --field-end--
 # --field-start--
 fieldName=name
 columnName=name
 # --field-end--
 # --field-start--
-fieldName=zabbixServerId
-columnName=zabbixserverid
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.ZabbixServer
-tableName=zabbixservers
-# --table-fields-start--
-# --field-start--
-fieldName=id
-columnName=zabbixserverid
-generatedId=true
-# --field-end--
-# --field-start--
-fieldName=name
-columnName=name
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.TriggerHostGroupRelation
-tableName=trigger_hostgroup_relation
-# --table-fields-start--
-# --field-start--
-fieldName=id
-generatedId=true
-# --field-end--
-# --field-start--
-fieldName=trigger
-columnName=triggerid
+fieldName=host
+columnName=host
 foreign=true
-uniqueIndexName=trigger_group_idx
-# --field-end--
-# --field-start--
-fieldName=group
-columnName=groupid
-foreign=true
-uniqueIndexName=trigger_group_idx
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.HostGroup
-tableName=hostgroups
-# --table-fields-start--
-# --field-start--
-fieldName=groupId
-columnName=groupid
-id=true
-# --field-end--
-# --field-start--
-fieldName=name
-columnName=name
-# --field-end--
-# --field-start--
-fieldName=zabbixServerId
-columnName=zabbixserverid
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.Event
-tableName=events
-# --table-fields-start--
-# --field-start--
-fieldName=id
-columnName=eventid
-id=true
-# --field-end--
-# --field-start--
-fieldName=objectId
-columnName=objectid
-# --field-end--
-# --field-start--
-fieldName=trigger
-columnName=triggerid
-foreign=true
+uniqueIndexName=screen_host_idx
 foreignAutoRefresh=true
-foreignAutoCreate=true
 # --field-end--
 # --field-start--
-fieldName=clock
-columnName=clock
+fieldName=zabbixServerId
+columnName=zabbixserverid
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.ScreenItem
+tableName=screenitems
+# --table-fields-start--
+# --field-start--
+fieldName=id
+columnName=screenitemid
+id=true
 # --field-end--
 # --field-start--
-fieldName=value
-columnName=value
+fieldName=screenId
+columnName=screenid
+indexName=screenitems_screenid_idx
 # --field-end--
 # --field-start--
-fieldName=acknowledged
-columnName=acknowledged
-# --field-end--
-# --field-start--
-fieldName=hostNames
+fieldName=resourceId
+columnName=resourceid
 # --field-end--
 # --table-fields-end--
 # --table-end--
@@ -392,44 +408,40 @@ fieldName=hostNames
 # --table-end--
 #################################
 # --table-start--
-dataClass=com.inovex.zabbixmobile.model.Host
-tableName=hosts
-# --table-fields-start--
-# --field-start--
-fieldName=id
-columnName=hostid
-id=true
-# --field-end--
-# --field-start--
-fieldName=name
-columnName=host
-# --field-end--
-# --field-start--
-fieldName=status
-columnName=status
-# --field-end--
-# --table-fields-end--
-# --table-end--
-#################################
-# --table-start--
-dataClass=com.inovex.zabbixmobile.model.HostHostGroupRelation
-tableName=host_hostgroup_relation
+dataClass=com.inovex.zabbixmobile.model.TriggerHostGroupRelation
+tableName=trigger_hostgroup_relation
 # --table-fields-start--
 # --field-start--
 fieldName=id
 generatedId=true
 # --field-end--
 # --field-start--
-fieldName=host
-columnName=hostid
+fieldName=trigger
+columnName=triggerid
 foreign=true
-uniqueIndexName=host_group_idx
+uniqueIndexName=trigger_group_idx
 # --field-end--
 # --field-start--
 fieldName=group
 columnName=groupid
 foreign=true
-uniqueIndexName=host_group_idx
+uniqueIndexName=trigger_group_idx
+# --field-end--
+# --table-fields-end--
+# --table-end--
+#################################
+# --table-start--
+dataClass=com.inovex.zabbixmobile.model.ZabbixServer
+tableName=zabbixservers
+# --table-fields-start--
+# --field-start--
+fieldName=id
+columnName=zabbixserverid
+generatedId=true
+# --field-end--
+# --field-start--
+fieldName=name
+columnName=name
 # --field-end--
 # --table-fields-end--
 # --table-end--

--- a/src/main/res/raw/ormlite_config.txt
+++ b/src/main/res/raw/ormlite_config.txt
@@ -1,5 +1,5 @@
 #
-# generated on 2015/08/28 03:51:37
+# generated on 2015/08/28 04:26:18
 #
 # --table-start--
 dataClass=com.inovex.zabbixmobile.model.Application
@@ -334,8 +334,13 @@ tableName=screenitems
 # --table-fields-start--
 # --field-start--
 fieldName=id
+columnName=id
+generatedId=true
+# --field-end--
+# --field-start--
+fieldName=screenItemId
 columnName=screenitemid
-id=true
+uniqueIndexName=screenitem_host_idx
 # --field-end--
 # --field-start--
 fieldName=screenId
@@ -345,6 +350,17 @@ indexName=screenitems_screenid_idx
 # --field-start--
 fieldName=resourceId
 columnName=resourceid
+# --field-end--
+# --field-start--
+fieldName=host
+columnName=host
+foreign=true
+uniqueIndexName=screenitem_host_idx
+foreignAutoRefresh=true
+# --field-end--
+# --field-start--
+fieldName=realResourceId
+columnName=real_resourceid
 # --field-end--
 # --table-fields-end--
 # --table-end--


### PR DESCRIPTION
Please review the code changes for issue #37.
Now, template screens are shown as well in the screens list. This required some database adjustments as the template screens always have the same ID, but are delivered by Zabbix for multiple hosts (those using the template) with different screen items (linking to the specific graphs for the respective host).